### PR TITLE
Add OpenFlight CentOS Base Image to Supported Regions

### DIFF
--- a/examples/aws/domain.yaml
+++ b/examples/aws/domain.yaml
@@ -12,7 +12,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
 
   myclusterInternetGateway:
@@ -24,7 +24,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
   
   myclusterInternetGatewayAttachment:
@@ -43,7 +43,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
 
   myclusternetwork1Subnet:
@@ -59,7 +59,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
 
   network1SubnetRouteTableAssocation:
@@ -107,7 +107,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
 
 Outputs:

--- a/examples/aws/node.yaml
+++ b/examples/aws/node.yaml
@@ -4,6 +4,36 @@ Mappings:
   RegionMap:
     eu-west-2:
       "AMI": "ami-05c72636444d6f86c"
+    eu-north-1:
+      "AMI": "ami-0d47713982efd31ec"
+    ap-south-1:
+      "AMI": "ami-062358b492c2a9a4d"
+    eu-west-3:
+      "AMI": "ami-0fc9d8b5acbc07d8f"
+    eu-west-1:
+      "AMI": "ami-0ae715c5263451742"
+    ap-northeast-2:
+      "AMI": "ami-06ec50277fdc63ab3"
+    ap-northeast-1:
+      "AMI": "ami-0bfb023152ee2a42b"
+    sa-east-1:
+      "AMI": "ami-04054e245a2d342e7"
+    ca-central-1:
+      "AMI": "ami-077f407a4418df652"
+    ap-southeast-1:
+      "AMI": "ami-02b7dfce2332f7d80"
+    ap-southeast-2:
+      "AMI": "ami-064c2e901fd404028"
+    eu-central-1:
+      "AMI": "ami-0f9263422d91f6eaf"
+    us-east-1:
+      "AMI": "ami-0f70ff212b23be6d7"
+    us-east-2:
+      "AMI": "ami-017b202f3780ae884"
+    us-west-1:
+      "AMI": "ami-0a033ffddd7425b15"
+    us-west-2:
+      "AMI": "ami-02f12273e580aaebc"
 Resources:
 
   mynodenetwork1Interface:

--- a/examples/aws/node.yaml
+++ b/examples/aws/node.yaml
@@ -18,7 +18,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
 
   mynode:
@@ -40,7 +40,7 @@ Resources:
           Key: 'Name'
           Value: '%deployment_name%'
         -
-          Key: 'alcescluster'
+          Key: 'flightcluster'
           Value: %deployment_name%
       UserData:
         Fn::Base64:

--- a/examples/aws/node.yaml
+++ b/examples/aws/node.yaml
@@ -2,10 +2,8 @@
 Description: 'Flight Domain Template'
 Mappings:
   RegionMap:
-    eu-west-1:
-      "AMI": "ami-d266dfab"
     eu-west-2:
-      "AMI": "ami-c5f11ea2"
+      "AMI": "ami-05c72636444d6f86c"
 Resources:
 
   mynodenetwork1Interface:

--- a/examples/azure/domain.json
+++ b/examples/azure/domain.json
@@ -8,7 +8,7 @@
       "apiVersion": "2017-03-01",
       "tags": {
         "Name": "%deployment_name%",
-        "alcescluster": "%deployment_name%"
+        "flightcluster": "%deployment_name%"
       },
       "location": "[resourceGroup().location]",
       "properties": {
@@ -33,7 +33,7 @@
       "apiVersion": "2017-03-01",
       "tags": {
         "Name": "%deployment_name%",
-        "alcescluster": "%deployment_name%"
+        "flightcluster": "%deployment_name%"
       },
       "location": "[resourceGroup().location]",
       "properties": {

--- a/examples/azure/node.json
+++ b/examples/azure/node.json
@@ -13,7 +13,7 @@
       "apiVersion": "2017-03-01",
       "tags": {
         "Name": "%deployment_name%",
-        "alcescluster": "%deployment_name%"
+        "flightcluster": "%deployment_name%"
       },
       "location": "[resourceGroup().location]",
       "properties": {
@@ -30,7 +30,7 @@
       "apiVersion": "2017-03-01",
       "tags": {
         "Name": "%deployment_name%",
-        "alcescluster": "%deployment_name%"
+        "flightcluster": "%deployment_name%"
       },
       "location": "[resourceGroup().location]",
       "properties": {
@@ -60,7 +60,7 @@
       "apiVersion": "2016-04-30-preview",
       "tags": {
         "Name": "%deployment_name%",
-        "alcescluster": "%deployment_name%"
+        "flightcluster": "%deployment_name%"
       },
       "location": "[resourceGroup().location]",
       "properties": {
@@ -80,12 +80,12 @@
     },
 	"osProfile": {
           "computerName": "mynode.pri.mycluster.cluster.local",
-          "adminUsername": "alces",
+          "adminUsername": "centos",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
             "publicKeys": [{
-              "path": "[concat ('/home/alces', '/.ssh/authorized_keys')]",
+              "path": "[concat ('/home/centos', '/.ssh/authorized_keys')]",
               "keyData": "%publicsshkey%"
               }]
             }

--- a/examples/azure/node.json
+++ b/examples/azure/node.json
@@ -4,6 +4,32 @@
   "variables": {
       "images": {
           "uksouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure"
+          "australiaeast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-australiaeast",
+          "australiasoutheast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-australiasoutheast",
+          "brazilsouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-brazilsouth",
+          "canadacentral": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-canadacentral",
+          "canadaeast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-canadaeast",
+          "centralindia": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-centralindia",
+          "centralus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-centralus",
+          "eastasia": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-eastasia",
+          "eastus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-eastus",
+          "eastus2": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-eastus2",
+          "francecentral": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-francecentral",
+          "japaneast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-japaneast",
+          "japanwest": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-japanwest",
+          "koreacentral": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-koreacentral",
+          "koreasouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-koreasouth",
+          "northcentralus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-northcentralus",
+          "northeurope": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-northeurope",
+          "southcentralus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-southcentralus",
+          "southeastasia": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-southeastasia",
+          "southindia": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-southindia",
+          "ukwest": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-ukwest",
+          "westcentralus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-westcentralus",
+          "westeurope": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-westeurope",
+          "westindia": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-westindia",
+          "westus": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-westus",
+          "westus2": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-westus2"
           }
   },
   "resources": [

--- a/examples/azure/node.json
+++ b/examples/azure/node.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "variables": {
+      "images": {
+          "uksouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure"
+          }
+  },
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",
@@ -62,20 +67,17 @@
         "hardwareProfile": {
 	  "vmSize": "Standard_DS3_v2"
 	},
-        "storageProfile": {
-	  "imageReference": {
-            "publisher": "OpenLogic",
-            "offer": "CentOS",
-            "sku": "7.3",
-            "version": "latest"
-	  },
-	  "osDisk": {
-	    "createOption": "fromImage",
-	    "managedDisk": {
-              "storageAccountType": "Premium_LRS"
-	    }
-	  }
-	},
+    "storageProfile": {
+        "osDisk": {
+            "createOption": "fromImage",
+            "managedDisk": {
+                "storageAccountType": "Premium_LRS"
+            }
+        },
+        "imageReference": {
+            "id": "[variables('images')[resourceGroup().location]]"
+        }
+    },
 	"osProfile": {
           "computerName": "mynode.pri.mycluster.cluster.local",
           "adminUsername": "alces",

--- a/examples/azure/node.json
+++ b/examples/azure/node.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "variables": {
       "images": {
-          "uksouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure"
+          "uksouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure",
           "australiaeast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-australiaeast",
           "australiasoutheast": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-australiasoutheast",
           "brazilsouth": "/subscriptions/d1e964ef-15c7-4b27-8113-e725167cee83/resourceGroups/openflight-cloud/providers/Microsoft.Compute/images/openflight-cloud-base-1.0-azure-brazilsouth",


### PR DESCRIPTION
This PR adds AMI IDs/Azure Resource Paths to the openflight CentOS 7 Base image (built with [cloudware-images](https://github.com/alces-software/cloudware-images)) to all supported regions.

Additionally, this removes any references to "alces" from the templates.