### PR TITLE
Fix running power commands on groups

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -255,7 +255,7 @@ module Cloudware
       cli_attr = 'IDENTIFIER'
       cli_syntax(c, cli_attr)
       c.option '-g', '--group', <<~DESC
-        Preform the '#{action}' action on machine in group '#{cli_attr}'
+        Perform the '#{action}' action on machine in group '#{cli_attr}'
       DESC
     end
 

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -46,7 +46,7 @@ module Cloudware
 
         def machines
           if options.group
-            Deployments.read(__config__.current_cluster)
+            Models::Deployments.read(__config__.current_cluster)
                        .machines
                        .select { |m| m.groups.include?(identifier) }
           else


### PR DESCRIPTION
This PR fixes the `group` option for the `power` commands.

Addresses part of #219