### PR TITLE
Further group support

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -159,6 +159,7 @@ module Cloudware
         Once the deployment is offline, the configuration file can be
         permanetly removed using the 'delete' command.
       DESC
+      c.option '-g', '--group', 'Destroy all resources within the specified group'
       action(c, Commands::Destroy)
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -157,7 +157,7 @@ module Cloudware
         allowing it to be redeployed easily.
 
         Once the deployment is offline, the configuration file can be
-        permanetly removed using the 'delete' command.
+        permanently removed using the 'delete' command.
       DESC
       c.option '-g', '--group', 'Destroy all deployments within the specified group'
       action(c, Commands::Destroy)

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -159,7 +159,7 @@ module Cloudware
         Once the deployment is offline, the configuration file can be
         permanetly removed using the 'delete' command.
       DESC
-      c.option '-g', '--group', 'Destroy all resources within the specified group'
+      c.option '-g', '--group', 'Destroy all deployments within the specified group'
       action(c, Commands::Destroy)
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -144,6 +144,7 @@ module Cloudware
       DESC
       c.option '-p', '--params \'<REPLACE_KEY=*IDENTIFIER[.OUTPUT_KEY] >...\'',
                String, 'A space separated list of keys to be replaced'
+      c.option '-g', '--group', 'Deploy all resources within the specified group'
       action(c, Commands::Deploy)
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -175,6 +175,7 @@ module Cloudware
         using the '--force' flag. This will not destroy the remote resources
       DESC
       c.option '--force', 'Delete the deployment regardless if running'
+      c.option '-g', '--group', 'Delete all deployments within the specified group'
       action(c, Commands::Destroy, method: :delete)
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -129,7 +129,7 @@ module Cloudware
         deployment: NAME. This will result in an error if the deployment does
         not exist or is currently in a deployed state.
 
-        Calling it with a second argument will try and create a nem deployment
+        Calling it with a second argument will try and create a new deployment
         called NAME with the specified TEMPLATE. The TEMPLATE references the
         internal template which have been imported. Alternatively it can be
         an absolute path to a template file.

--- a/lib/cloudware/command.rb
+++ b/lib/cloudware/command.rb
@@ -67,6 +67,14 @@ module Cloudware
       __config__.region
     end
 
+    def get_machines_in_group(group_name)
+      Models::Deployments.read(__config__.current_cluster)
+        .machines
+        .select { |m| m.groups.include?(group_name) }
+        .map { |m| m.name }
+        .sort
+    end
+
     private
 
     def _render(template)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -108,14 +108,6 @@ module Cloudware
         raise InvalidInput, "'#{dep.name}' is already running"
         ERROR
       end
-
-      def get_machines_in_group(group_name)
-        Models::Deployments.read(__config__.current_cluster)
-          .machines
-          .select { |m| m.groups.include?(group_name) }
-          .map { |m| m.name }
-          .sort
-      end
     end
   end
 end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -54,11 +54,12 @@ module Cloudware
           puts "Deploying: #{cur_dep.path}"
           with_spinner('Deploying resources...', done: 'Done') do
             dep = Models::Deployment.deploy!(__config__.current_cluster, m)
-            return unless dep.deployment_error
-            raise DeploymentError, <<~ERROR.chomp
-               An error has occured. Please see for further details:
-              `#{Config.app_name} list deployments --verbose`
-            ERROR
+            if dep.deployment_error
+              raise DeploymentError, <<~ERROR.chomp
+                 An error has occured. Please see for further details:
+                `#{Config.app_name} list deployments --verbose`
+              ERROR
+            end
           end
         end
       end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -37,7 +37,7 @@ module Cloudware
         require 'cloudware/replacement_factory'
       end
 
-      def run!(name, raw_path = nil, params: nil)
+      def run!(name, raw_path = nil, params: nil, group: nil)
         cur_dep = if raw_path
           create_deployment(name, raw_path, params: params)
         else

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -39,8 +39,10 @@ module Cloudware
 
       def run
         @name = argv[0]
-        with_spinner('Destroying resources...', done: 'Done') do
-          Models::Deployment.destroy!(__config__.current_cluster, name)
+        machines.each do |m|
+          with_spinner('Destroying resources...', done: 'Done') do
+            Models::Deployment.destroy!(__config__.current_cluster, m)
+          end
         end
       end
 
@@ -49,6 +51,16 @@ module Cloudware
           Models::Deployment.delete(__config__.current_cluster, name)
         else
           Models::Deployment.delete!(__config__.current_cluster, name)
+        end
+      end
+
+      private
+
+      def machines
+        if options.group
+          get_machines_in_group(name)
+        else
+          [name]
         end
       end
     end

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -46,7 +46,7 @@ module Cloudware
                    end
 
         machines.each do |m|
-          with_spinner('Destroying resources...', done: 'Done') do
+          with_spinner("Destroying resources for #{m}...", done: 'Done') do
             Models::Deployment.destroy!(__config__.current_cluster, m)
           end
         end

--- a/lib/cloudware/commands/destroy.rb
+++ b/lib/cloudware/commands/destroy.rb
@@ -39,6 +39,12 @@ module Cloudware
 
       def run
         @name = argv[0]
+        machines = if options.group
+                     get_machines_in_group(name)
+                   else
+                     [name]
+                   end
+
         machines.each do |m|
           with_spinner('Destroying resources...', done: 'Done') do
             Models::Deployment.destroy!(__config__.current_cluster, m)
@@ -46,21 +52,19 @@ module Cloudware
         end
       end
 
-      def delete(name, force: false)
-        if force
-          Models::Deployment.delete(__config__.current_cluster, name)
-        else
-          Models::Deployment.delete!(__config__.current_cluster, name)
-        end
-      end
+      def delete(name, force: false, group: nil)
+        machines = if group
+                     get_machines_in_group(name)
+                   else
+                     [name]
+                   end
 
-      private
-
-      def machines
-        if options.group
-          get_machines_in_group(name)
-        else
-          [name]
+        machines.each do |m|
+          if force
+            Models::Deployment.delete(__config__.current_cluster, m)
+          else
+            Models::Deployment.delete!(__config__.current_cluster, m)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR resolves #219 by adding group support to the remaining commands listed there; deploy, destroy and delete.

When using the group flag on these commands they behave as if the command had been run on each resource within that group individually.