### PR TITLE
Clear error when deployment is destroyed

### DIFF
--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -174,6 +174,7 @@ module Cloudware
 
       def destroy(force: false)
         provider_client.destroy(tag)
+        __data__.delete("deployment_error") if self.deployment_error
         self.deployed = false
         true
       rescue => e


### PR DESCRIPTION
This prevents stale errors from claiming an error has occurred when the deployment has actually succeeded.

Fixes #216.