### PR TITLE
Resolve domain(s) on deployment

### DIFF
--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -52,10 +52,12 @@ module Cloudware
           end
           raise_if_deployed(cur_dep)
 
-          dependencies = cur_dep.replacements.map { |key, value|
-            next unless value.include? "*"
+          dependencies = cur_dep.replacements.select { |key, value|
+            # Select only values to be resolved
+            value.include? "*"
+          }.each_value.uniq.map { |value|
             Models::Deployment.read(__config__.current_cluster, (value.delete "*"))
-          }.uniq.compact
+          }
 
           dependencies.each do |d|
             unless d.deployed

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -57,6 +57,13 @@ module Cloudware
             Models::Deployment.read(__config__.current_cluster, (value.delete "*"))
           }.uniq.compact
 
+          dependencies.each do |d|
+            unless d.deployed
+              puts "Deploying dependency: #{d.name}"
+              deploy(d.name)
+            end
+          end
+
           puts "Deploying: #{cur_dep.path}"
           deploy(m)
         end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -51,16 +51,9 @@ module Cloudware
             Models::Deployment.read!(__config__.current_cluster, m)
           end
           raise_if_deployed(cur_dep)
+
           puts "Deploying: #{cur_dep.path}"
-          with_spinner('Deploying resources...', done: 'Done') do
-            dep = Models::Deployment.deploy!(__config__.current_cluster, m)
-            if dep.deployment_error
-              raise DeploymentError, <<~ERROR.chomp
-                 An error has occured. Please see for further details:
-                `#{Config.app_name} list deployments --verbose`
-              ERROR
-            end
-          end
+          deploy(m)
         end
       end
 
@@ -107,6 +100,18 @@ module Cloudware
         return unless dep.deployed
         raise InvalidInput, "'#{dep.name}' is already running"
         ERROR
+      end
+
+      def deploy(machine)
+        with_spinner('Deploying resources...', done: 'Done') do
+          dep = Models::Deployment.deploy!(__config__.current_cluster, machine)
+          if dep.deployment_error
+            raise DeploymentError, <<~ERROR.chomp
+               An error has occured. Please see for further details:
+              `#{Config.app_name} list deployments --verbose`
+            ERROR
+          end
+        end
       end
     end
   end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -52,6 +52,11 @@ module Cloudware
           end
           raise_if_deployed(cur_dep)
 
+          dependencies = cur_dep.replacements.map { |key, value|
+            next unless value.include? "*"
+            Models::Deployment.read(__config__.current_cluster, (value.delete "*"))
+          }.uniq.compact
+
           puts "Deploying: #{cur_dep.path}"
           deploy(m)
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -155,7 +155,11 @@ module Cloudware
 
       def template
         return raw_template unless replacements
+        dep = ReplacementFactory.new(cluster, self.name)
         replacements.reduce(raw_template) do |memo, (key, value)|
+          # Resolve domain(s) of key value pairs if necessary
+          value = dep.parse_key_pair(key.to_sym, value) if value.include? "*"
+
           memo.gsub("%#{key}%", value.to_s)
         end
       end

--- a/lib/cloudware/replacement_factory.rb
+++ b/lib/cloudware/replacement_factory.rb
@@ -76,7 +76,7 @@ module Cloudware
       end
       keys, value = components
       keys.split(',').map do |key|
-        [key.to_sym, parse_key_pair(key.to_sym, value)]
+        [key.to_sym, value]
       end.to_h
     end
 

--- a/spec/cloudware/replacement_factory_spec.rb
+++ b/spec/cloudware/replacement_factory_spec.rb
@@ -153,10 +153,6 @@ RSpec.describe Cloudware::ReplacementFactory do
       include_context 'parse-param-deployment'
 
       it_behaves_like 'a default replacement'
-
-      it 'replaces the referenced result' do
-        expect(subject.build(input_string)).to include(key => result_string)
-      end
     end
 
     context 'with multi key-pair input string' do


### PR DESCRIPTION
This PR adjusts how nodes are stored and handled during initial deployment or redeployment. Previously any parameters that had a domain specified would replace that value with the matching key found within the given domain. 

However this meant that if the domain was destroyed and redeployed it would no longer have matching configuration values and the node had no way of redeploying successfully without being deleted and recreated against the new instances of the domain(s).

Now though the relevant domain for a given parameter is stored as the value within the configuration file and is resolved as needed. The provider still receives the same data as before but now the node can be successfully redeployed against fresh instances of any dependencies it has.

If there are any dependencies that are not currently deployed when trying to deploy a node then Flight Cloud will deploy those first before attempting to deploy the node itself. This interaction is something that might need to be changed in the future, potentially prompting for permission to deploy any missing dependencies.

Resolves #212 when merged.