### PR TITLE
Configure user access details for provider(s)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rubyzip'
 gem 'tty-markdown'
 gem 'tty-spinner'
 gem 'tty-table'
+gem 'tty-prompt'
 
 group :config do
   gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       unicode_utils (~> 1.4.0)
     thread_safe (0.3.6)
     timeliness (0.3.8)
+    timers (4.3.0)
     tty-color (0.4.3)
     tty-config (0.3.1)
     tty-cursor (0.6.0)
@@ -131,6 +132,16 @@ GEM
       strings (~> 0.1.0)
       tty-color (~> 0.4.2)
       tty-screen (~> 0.6.4)
+    tty-prompt (0.18.1)
+      necromancer (~> 0.4.0)
+      pastel (~> 0.7.0)
+      timers (~> 4.0)
+      tty-cursor (~> 0.6.0)
+      tty-reader (~> 0.5.0)
+    tty-reader (0.5.0)
+      tty-cursor (~> 0.6.0)
+      tty-screen (~> 0.6.4)
+      wisper (~> 2.0.0)
     tty-screen (0.6.5)
     tty-spinner (0.9.0)
       tty-cursor (~> 0.6.0)
@@ -147,6 +158,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.3)
     unicode_utils (1.4.0)
+    wisper (2.0.0)
 
 PLATFORMS
   ruby
@@ -178,6 +190,7 @@ DEPENDENCIES
   rubocop-rspec
   rubyzip
   tty-markdown
+  tty-prompt
   tty-spinner
   tty-table
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -299,5 +299,11 @@ module Cloudware
       DESC
       action(c, Commands::Deploy, method: :render)
     end
+
+    command 'configure' do |c|
+      cli_syntax(c)
+      c.description = 'Configure access details for the current provider'
+      action(c, Commands::Configure)
+    end
   end
 end

--- a/lib/cloudware/commands/configure.rb
+++ b/lib/cloudware/commands/configure.rb
@@ -36,6 +36,10 @@ module Cloudware
         file_data = IO.readlines(Config.path)
         access_details = Config.provider_details
 
+        if access_details.nil?
+          raise ConfigError, 'No provider details found'
+        end
+
         # Grab the line number in the config corresponding to the current
         # provider
         line_number = nil

--- a/lib/cloudware/commands/configure.rb
+++ b/lib/cloudware/commands/configure.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Cloud.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Cloud is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Cloud. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Cloud, please visit:
+# https://github.com/openflighthpc/flight-cloud
+#===============================================================================
+
+require 'tty-prompt'
+
+module Cloudware
+  module Commands
+    class Configure < Command
+      def run
+        file_data = IO.readlines(Config.path)
+        access_details = Config.provider_details
+
+        # Grab the line number in the config corresponding to the current
+        # provider
+        line_number = nil
+        file_data.each_with_index do |line, index|
+          if line.include?("#{Config.provider}:")
+            line_number = index + 1
+          end
+        end
+
+        prompt = TTY::Prompt.new
+        puts "Provide access details for #{Config.provider}:"
+        access_details.each_with_index do |(k, v), i|
+          # Given the line number found before we know where in the config
+          # file the access details are expected
+          new_v = prompt.ask(k, default: v)
+          file_data[line_number + i] = file_data[line_number + i].sub(v, new_v)
+        end
+
+        # Write the changes to the config file
+        IO.write(Config.path, file_data.join)
+      end
+    end
+  end
+end

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -74,6 +74,10 @@ module Cloudware
       end
     end
 
+    def provider_details
+      __data__.fetch(provider)
+    end
+
     def prefix_tag
       __data__.fetch(:prefix_tag, default: 'cloudware-shared')
     end


### PR DESCRIPTION
This PR adds the new `configure` command that allows the user to configure user access details for the current provider.

Resolves #214 when merged. 