### PR TITLE
Prompt for missing parameters

### DIFF
--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -61,7 +61,8 @@ module Cloudware
             dep.cluster_config.templates.resolve_human_path(template)
           end
           dep.replacements = replacements
-          dep.validate_or_error('create')
+          dep.validate
+          dep.error('create') unless dep.errors.blank?
         end
       rescue FlightConfig::CreateError => e
         if read_or_new(*a).deployed
@@ -216,6 +217,12 @@ module Cloudware
 
       def validate_or_error(action)
         validate
+        unless errors.blank?
+          raise ModelValidationError, render_errors_message(action)
+        end
+      end
+
+      def error(action)
         unless errors.blank?
           raise ModelValidationError, render_errors_message(action)
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -219,9 +219,7 @@ module Cloudware
 
       def validate_or_error(action)
         validate
-        unless errors.blank?
-          raise ModelValidationError, render_errors_message(action)
-        end
+        error(action) unless errors.blank?
       end
 
       def error(action)

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -62,6 +62,8 @@ module Cloudware
           end
           dep.replacements = replacements
           dep.validate
+          dep.replacements.merge!((yield dep.errors.messages.keys if dep.errors))
+          dep.validate # Second validation to potentially clear any previous errors
           dep.error('create') unless dep.errors.blank?
         end
       rescue FlightConfig::CreateError => e


### PR DESCRIPTION
When attempting to deploy a resource for the first time the user will be prompted to input values for any parameters they didn't initially provide. Once the user has finished entering these values the application will validate the deployment again and attempt to deploy the resource.

Resolves #222 when merged.