### PR TITLE
Configure command adjustments

### DIFF
--- a/lib/cloudware/commands/configure.rb
+++ b/lib/cloudware/commands/configure.rb
@@ -54,7 +54,7 @@ module Cloudware
         access_details.each_with_index do |(k, v), i|
           # Given the line number found before we know where in the config
           # file the access details are expected
-          new_v = prompt.ask(k, default: v)
+          new_v = prompt.ask("#{k}:", default: v)
           file_data[line_number + i] = file_data[line_number + i].sub(v, new_v)
         end
 

--- a/lib/cloudware/commands/configure.rb
+++ b/lib/cloudware/commands/configure.rb
@@ -33,6 +33,8 @@ module Cloudware
   module Commands
     class Configure < Command
       def run
+        create_config_file unless File.exist? Config.path
+
         file_data = IO.readlines(Config.path)
         access_details = Config.provider_details
 
@@ -60,6 +62,13 @@ module Cloudware
 
         # Write the changes to the config file
         IO.write(Config.path, file_data.join)
+      end
+
+      private
+
+      def create_config_file
+        puts "Config file missing. Creating file at #{Config.path}..."
+        FileUtils.cp(Config.path + '.example', Config.path)
       end
     end
   end

--- a/lib/cloudware/commands/configure.rb
+++ b/lib/cloudware/commands/configure.rb
@@ -54,8 +54,8 @@ module Cloudware
         access_details.each_with_index do |(k, v), i|
           # Given the line number found before we know where in the config
           # file the access details are expected
-          new_v = prompt.ask("#{k}:", default: v)
-          file_data[line_number + i] = file_data[line_number + i].sub(v, new_v)
+          file_data[line_number + i] = file_data[line_number + i]
+          .gsub(/:(.*)#/im, ": #{prompt.ask("#{k}:", default: v)} #")
         end
 
         # Write the changes to the config file

--- a/lib/cloudware/config.rb
+++ b/lib/cloudware/config.rb
@@ -75,7 +75,7 @@ module Cloudware
     end
 
     def provider_details
-      __data__.fetch(provider)
+      Data.load(path)[provider.to_sym]
     end
 
     def prefix_tag


### PR DESCRIPTION
This PR contains several adjustments to the `configure` command:
* Empty/nil default values no longer break the command
     * Fixes #231 
* If the config file is missing then it will attempt to create it by copying the example file
     * Fixes #230 