### PR TITLE
Default values for prompted parameters if references are given

### DIFF
--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -81,13 +81,17 @@ module Cloudware
         replacements = {}
         previous_param = nil
 
+        # Prompt the user for each missing parameter
         missing_params.map { |p| p.to_s.delete('%') }.each do |p|
           key = p.to_sym
 
           replacements[key] = prompt.ask("#{p}:") do |q|
+            # If the previous parameter is a resource reference then offer it
+            # as the default value for this parameter
             q.default previous_param unless previous_param.nil?
           end
 
+          # Set as the value of the parameter if it is a resource reference
           previous_param = replacements[key] if replacements[key]&.include? '*'
         end
 

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -79,8 +79,13 @@ module Cloudware
         prompt = TTY::Prompt.new
 
         replacements = {}
+        previous_error = nil
         errors.each do |e|
-          replacements[e.to_s.delete('%').to_sym] = prompt.ask("#{e}:")
+          key = e.to_s.delete('%').to_sym
+          replacements[key] = prompt.ask("#{e}:") do |q|
+            q.default previous_error unless previous_error.nil?
+          end
+          previous_error = replacements[key] if replacements[key]&.include? '*'
         end
 
         return replacements

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -73,19 +73,19 @@ module Cloudware
         end
       end
 
-      def prompt_for_params(errors)
+      def prompt_for_params(missing_params)
         puts "Please provide values for the following missing parameters:"
         puts "(Note: Use the format of *<resource_name> to reference a resource)"
         prompt = TTY::Prompt.new
 
         replacements = {}
-        previous_error = nil
-        errors.map { |e| e.to_s.delete('%') }.each do |e|
-          key = e.to_sym
-          replacements[key] = prompt.ask("#{e}:") do |q|
-            q.default previous_error unless previous_error.nil?
+        previous_param = nil
+        missing_params.map { |p| p.to_s.delete('%') }.each do |p|
+          key = p.to_sym
+          replacements[key] = prompt.ask("#{p}:") do |q|
+            q.default previous_param unless previous_param.nil?
           end
-          previous_error = replacements[key] if replacements[key]&.include? '*'
+          previous_param = replacements[key] if replacements[key]&.include? '*'
         end
 
         return replacements

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -80,8 +80,8 @@ module Cloudware
 
         replacements = {}
         previous_error = nil
-        errors.each do |e|
-          key = e.to_s.delete('%').to_sym
+        errors.map { |e| e.to_s.delete('%') }.each do |e|
+          key = e.to_sym
           replacements[key] = prompt.ask("#{e}:") do |q|
             q.default previous_error unless previous_error.nil?
           end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -80,11 +80,14 @@ module Cloudware
 
         replacements = {}
         previous_param = nil
+
         missing_params.map { |p| p.to_s.delete('%') }.each do |p|
           key = p.to_sym
+
           replacements[key] = prompt.ask("#{p}:") do |q|
             q.default previous_param unless previous_param.nil?
           end
+
           previous_param = replacements[key] if replacements[key]&.include? '*'
         end
 


### PR DESCRIPTION
The prompts for missing parameters will now provide a default option if the previous parameter was given a reference to another resource.

Example:

![image](https://user-images.githubusercontent.com/36155339/60605615-c4eab880-9db1-11e9-8cf9-10876c0059b1.png)

Resolves #236 when merged.