### PR TITLE
Correct the help text for the cluster init command

### DIFF
--- a/lib/cloudware/command_config.rb
+++ b/lib/cloudware/command_config.rb
@@ -54,7 +54,7 @@ module Cloudware
         raise ConfigError, <<~ERROR.chomp
           Can not currently preform this operation as a cluster has not been selected.
           Please select a cluster using either:
-          * '#{app_name} cluster init <provider> <new-cluster>
+          * '#{app_name} cluster init <new-cluster> <provider>
           * '#{app_name} cluster switch <existing-cluster>
         ERROR
       end


### PR DESCRIPTION
The help text now lists the required arguments in the correct order.

Fixes #253.