### PR TITLE
Prompt on deployment

### DIFF
--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -171,6 +171,8 @@ module Cloudware
     command 'deploy' do |c|
       cli_syntax(c, 'IDENTIFIER')
       c.summary = 'Deploy a domain or node'
+      c.option '-p', '--params \'<REPLACE_KEY=*IDENTIFIER[.OUTPUT_KEY] >...\'',
+        String, 'A space separated list of keys to be replaced'
       action(c, Commands::Deploy)
     end
 

--- a/lib/cloudware/commands/create.rb
+++ b/lib/cloudware/commands/create.rb
@@ -42,14 +42,12 @@ module Cloudware
       def domain(abs_template)
         Models::Domain.create!(__config__.current_cluster) do |domain|
           domain.save_template(abs_template)
-          domain.prompt_for_missing_replacements
         end
       end
 
       def node(name, abs_template, groups: nil)
         Models::Node.create!(__config__.current_cluster, name) do |node|
           node.save_template(abs_template)
-          node.prompt_for_missing_replacements
           node.groups = groups.split(',') if groups.is_a?(String)
         end
       end

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -39,16 +39,16 @@ module Cloudware
         require 'cloudware/replacement_factory'
       end
 
-      def run!(identifier, params=nil)
+      def run!(identifier, params: nil)
         if identifier == 'domain'
           domain(params)
         else
-          node(identifier, params)
+          node(identifier, params: params)
         end
       end
 
       # TODO: Handle dependent deployments at some point
-      def node(identifier, params)
+      def node(identifier, params: nil)
         replacements = ReplacementFactory.new(__config__.current_cluster, identifier)
           .build(params)
         node = Models::Node.prompt!(replacements, __config__.current_cluster, identifier)
@@ -65,7 +65,7 @@ module Cloudware
       end
 
       # TODO: DRY This up with above
-      def domain(params)
+      def domain(params: nil)
         domain = Models::Domain.prompt!(__config__.current_cluster)
         raise_if_deployed(domain)
         deployed_domain = with_spinner('Deploying domain...', done: 'Done') do

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -41,7 +41,7 @@ module Cloudware
 
       def run!(identifier, params: nil)
         if identifier == 'domain'
-          domain(params)
+          domain(params: params)
         else
           node(identifier, params: params)
         end
@@ -66,7 +66,9 @@ module Cloudware
 
       # TODO: DRY This up with above
       def domain(params: nil)
-        domain = Models::Domain.prompt!(__config__.current_cluster)
+        replacements = ReplacementFactory.new(__config__.current_cluster, 'domain')
+          .build(params)
+        domain = Models::Domain.prompt!(replacements, __config__.current_cluster)
         raise_if_deployed(domain)
         deployed_domain = with_spinner('Deploying domain...', done: 'Done') do
           Models::Domain.deploy!(__config__.current_cluster)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -49,7 +49,9 @@ module Cloudware
 
       # TODO: Handle dependent deployments at some point
       def node(identifier, params)
-        node = Models::Node.prompt!(__config__.current_cluster, identifier)
+        replacements = ReplacementFactory.new(__config__.current_cluster, identifier)
+          .build(params)
+        node = Models::Node.prompt!(replacements, __config__.current_cluster, identifier)
         raise_if_deployed(node)
         deployed_node = with_spinner('Deploying node...', done: 'Done') do
           Models::Node.deploy!(__config__.current_cluster, identifier)

--- a/lib/cloudware/commands/deploy.rb
+++ b/lib/cloudware/commands/deploy.rb
@@ -39,16 +39,16 @@ module Cloudware
         require 'cloudware/replacement_factory'
       end
 
-      def run!(identifier)
+      def run!(identifier, params=nil)
         if identifier == 'domain'
-          domain
+          domain(params)
         else
-          node(identifier)
+          node(identifier, params)
         end
       end
 
       # TODO: Handle dependent deployments at some point
-      def node(identifier)
+      def node(identifier, params)
         node = Models::Node.prompt!(__config__.current_cluster, identifier)
         raise_if_deployed(node)
         deployed_node = with_spinner('Deploying node...', done: 'Done') do
@@ -63,7 +63,7 @@ module Cloudware
       end
 
       # TODO: DRY This up with above
-      def domain
+      def domain(params)
         domain = Models::Domain.prompt!(__config__.current_cluster)
         raise_if_deployed(domain)
         deployed_domain = with_spinner('Deploying domain...', done: 'Done') do

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -95,6 +95,8 @@ module Cloudware
 
       def self.prompt!(replacements=nil, *a, all: false)
         reraise_missing_file do
+          puts "Please provide values for the following missing parameters:"
+          puts "(Note: Use the format of '*<resource_name>' to reference a resource)"
           update(*a) do |dep|
             dep.replacements = replacements
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -93,7 +93,7 @@ module Cloudware
         end
       end
 
-      def self.prompt!(*a, all: false)
+      def self.prompt!(replacements=nil, *a, all: false)
         reraise_missing_file do
           update(*a) do |dep|
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -96,7 +96,11 @@ module Cloudware
       def self.prompt!(replacements=nil, *a, all: false)
         reraise_missing_file do
           update(*a) do |dep|
-            dep.replacements = replacements
+            dep.replacements = dep.replacements.merge(
+              replacements.inject({}) { |memo, (k, v)|
+                memo[k.to_s] = v; memo
+              }
+            )
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements
           end
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -97,8 +97,6 @@ module Cloudware
         reraise_missing_file do
           update(*a) do |dep|
             dep.replacements = replacements
-            puts "Please provide values for the following missing parameters:"
-            puts "(Note: Use the format of '*<resource_name>' to reference a resource)"
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements
           end
         end
@@ -266,7 +264,14 @@ module Cloudware
       end
 
       def prompt_for_missing_replacements
-        missing_replacements.each { |k| ask_for_replacement(k) }
+        missing_replacements.each_with_index do |k, i|
+          if i == 0
+            puts "Please provide values for the following missing parameters:"
+            puts "(Note: Use the format of '*<resource_name>' to reference a resource)"
+          end
+
+          ask_for_replacement(k)
+        end
       end
 
       def edit_template

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -307,7 +307,7 @@ module Cloudware
 
       def ask_for_replacement(key)
         value = self.replacements[key]
-        self.replacements[key]= prompt.ask("%#{key}%:", default: value)
+        self.replacements[key]= prompt.ask("#{key}:", default: value)
       end
 
       def prompt

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -96,6 +96,7 @@ module Cloudware
       def self.prompt!(replacements=nil, *a, all: false)
         reraise_missing_file do
           update(*a) do |dep|
+            dep.replacements = replacements
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements
           end
         end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -256,7 +256,7 @@ module Cloudware
       end
 
       def missing_replacements
-        required_replacements - replacements.keys
+        required_replacements - replacements.keys.map { |k| k.to_s }
       end
 
       def prompt_for_all_replacements

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -95,10 +95,10 @@ module Cloudware
 
       def self.prompt!(replacements=nil, *a, all: false)
         reraise_missing_file do
-          puts "Please provide values for the following missing parameters:"
-          puts "(Note: Use the format of '*<resource_name>' to reference a resource)"
           update(*a) do |dep|
             dep.replacements = replacements
+            puts "Please provide values for the following missing parameters:"
+            puts "(Note: Use the format of '*<resource_name>' to reference a resource)"
             all ? dep.prompt_for_all_replacements : dep.prompt_for_missing_replacements
           end
         end


### PR DESCRIPTION
This PR makes some large adjustments to both the `create` and `deploy` command. The former no longer prompts for parameters as this functionality has been moved back to `deploy` (Resolves #256). 

To achieve this the concept of parameters was resurrected as arguments for the command allowing the user to provide the parameters without being prompted. This can also be used to overwrite existing parameters assigned to the resource.

Doing the aforementioned changes also meant that parameters provided in the CLI will no longer be prompted for e.g. `deployment_name` (Fixes #257).
