### PR TITLE
Add default region to list of required keys

### DIFF
--- a/lib/cloudware/providers/aws_interface.rb
+++ b/lib/cloudware/providers/aws_interface.rb
@@ -40,7 +40,11 @@ module Cloudware
         end
 
         def self.required_keys
-          [:access_key_id, :secret_access_key]
+          [
+            :access_key_id,
+            :secret_access_key,
+            :default_region
+          ]
         end
 
         private_class_method

--- a/lib/cloudware/providers/azure_interface.rb
+++ b/lib/cloudware/providers/azure_interface.rb
@@ -40,7 +40,13 @@ module Cloudware
         end
 
         def self.required_keys
-          [:subscription_id, :tenant_id, :client_id, :client_secret]
+          [
+            :subscription_id,
+            :tenant_id,
+            :client_id,
+            :client_secret,
+            :default_region
+          ]
         end
 
         private_class_method


### PR DESCRIPTION
This PR fixes #265 by adding `default_region` to the list of required keys for both AWS and Azure.