### PR TITLE
Improve error handling on undeployed nodes

### DIFF
--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -36,7 +36,8 @@ module Cloudware
 
       def status_cli(*a)
         set_arguments(*a)
-        machines.each  { |m| puts "#{m.name}: #{m.status rescue 'undeployed'}"}
+        machines.sort_by { |m| m.name }
+          .each  { |m| puts "#{m.name}: #{m.status rescue 'undeployed'}"}
       end
 
       def on_cli(*a)

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -36,7 +36,7 @@ module Cloudware
 
       def status_cli(*a)
         set_arguments(*a)
-        machines.each  { |m| puts "#{m.name}: #{m.status}"}
+        machines.each  { |m| puts "#{m.name}: #{m.status rescue 'undeployed'}"}
       end
 
       def on_cli(*a)

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -36,8 +36,7 @@ module Cloudware
 
       def status_cli(*a)
         set_arguments(*a)
-        machines.sort_by { |m| m.name }
-          .each  { |m| puts "#{m.name}: #{m.status rescue 'undeployed'}"}
+        machines.each  { |m| puts "#{m.name}: #{m.status rescue 'undeployed'}"}
       end
 
       def on_cli(*a)
@@ -94,7 +93,8 @@ module Cloudware
 
       def machines
         if group
-          Models::Group.read(__config__.current_cluster, identifier).nodes.map do |node|
+          Models::Group.read(__config__.current_cluster, identifier).nodes.sort_by { |n| n.name }
+            .map do |node|
             Models::Machine.new(name: node.name, cluster: __config__.current_cluster)
           end
         else

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -58,7 +58,7 @@ module Cloudware
 
       def status_hash(*a)
         set_arguments(*a)
-        hashify_machines { |m| m.status }
+        hashify_machines { |m| m.status rescue 'undeployed'}
       end
 
       def on_hash(*a)

--- a/lib/cloudware/models/machine.rb
+++ b/lib/cloudware/models/machine.rb
@@ -80,12 +80,7 @@ module Cloudware
       end
 
       def provider_id
-        fetch_result(PROVIDER_ID_FLAG) do |long_tag|
-          raise ModelValidationError, <<-ERROR.squish
-            Machine '#{name}' is missing its provider ID. Make sure
-            '#{long_tag}' is set within the deployment output
-          ERROR
-        end
+        fetch_result(PROVIDER_ID_FLAG)
       end
 
       def groups
@@ -138,7 +133,8 @@ module Cloudware
       private
 
       def machine_client
-        provider_client.machine(provider_id)
+        id = provider_id
+        provider_client.machine(id) if id
       end
       memoize :machine_client
     end


### PR DESCRIPTION
The power commands no longer error out when they encounter a node that is missing its provider ID. Instead the output will indicate that this node is undeployed, giving the user information on all nodes within a group whether one or more nodes are undeployed or not.

Resolves #267.