### PR TITLE
Treat non-existent nodes properly

### DIFF
--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -57,7 +57,7 @@ module Cloudware
 
       def status_hash(*a)
         set_arguments(*a)
-        hashify_machines { |m| m.status rescue 'undeployed'}
+        hashify_machines { |m| m.status }
       end
 
       def on_hash(*a)
@@ -87,6 +87,8 @@ module Cloudware
             memo[:errors][machine.name] = e.message
           rescue FlightConfig::MissingFile
             memo[:errors][machine.name] = 'Node does not exist'
+          rescue Module::DelegationError
+            memo[:nodes][machine.name] = 'undeployed'
           end
         end
       end

--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -86,7 +86,7 @@ module Cloudware
           rescue CloudwareError => e
             memo[:errors][machine.name] = e.message
           rescue FlightConfig::MissingFile
-            memo[:errors][machine.name] = 'Node does not exist'
+            memo[:errors][machine.name] = 'The node does not exist'
           rescue Module::DelegationError
             memo[:nodes][machine.name] = 'undeployed'
           end

--- a/lib/cloudware/models/deployment.rb
+++ b/lib/cloudware/models/deployment.rb
@@ -135,7 +135,7 @@ module Cloudware
       def self.reraise_missing_file
         yield if block_given?
       rescue FlightConfig::MissingFile => e
-        raise e.exception "The deployment does not exist"
+        raise e.exception "The deployment is not configured"
       end
 
       data_reader(:replacements) do |r|


### PR DESCRIPTION
Any nodes that do not exist will no longer be incorrectly marked as `undeployed` and will instead return the correct error that the node does not exist.

Fixes #269.