### PR TITLE
Support filtering the list by group

### DIFF
--- a/app/routes.rb
+++ b/app/routes.rb
@@ -59,7 +59,7 @@ module App
 
     namespace '/list' do
       get '' do
-        json Cloudware::Commands::Lists::Deployment.new.client_list
+        json Cloudware::Commands::Lists::Deployment.new.client_list(group: group_param)
       end
     end
 

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -59,7 +59,7 @@ module App
 
     namespace '/list' do
       get '' do
-        json Cloudware::Commands::Lists::Deployment.new.client_list(group: group_param)
+        json Cloudware::Commands::Lists::Deployment.new.client_list(group: params[:group])
       end
     end
 

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -257,6 +257,7 @@ module Cloudware
       cli_syntax(c)
       c.description = 'List all the previous deployed templates'
       c.option '-a', '--all', 'Include offline deployments'
+      c.option '-g GROUP', '--group GROUP', 'Filter the list by group'
       c.option '-v', '--verbose', 'Show full error messages'
       action(c, Commands::Lists::Deployment)
     end

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -51,13 +51,13 @@ module Cloudware
           end
         end
 
-        def client_list
-          hashify_list
+        def client_list(group: nil)
+          hashify_list(group)
         end
 
         private
 
-        def hashify_list
+        def hashify_list(group)
           deployments(group)
             .each_with_object({ running: {}, offline: {} }) do |deployment, memo|
             status = deployment.deployed ? 'Running' : 'Offline'

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -70,16 +70,11 @@ module Cloudware
 
         def deployments(group)
           registry = FlightConfig::Registry.new
-          resources = [
+          [
             Models::Domain.read(__config__.current_cluster, registry: registry),
             *Models::Node.glob_read(__config__.current_cluster, '*', registry: registry)
           ].sort_by { |r| r.name }
-
-          if group
-            resources.select { |r| r.groups.include? group if r.respond_to?(:groups) }
-          end
-
-          resources
+            .select { |r| group ? (r.groups.include? group if r.respond_to?(:groups)) : r }
         end
       end
     end

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -73,7 +73,7 @@ module Cloudware
           resources = [
             Models::Domain.read(__config__.current_cluster, registry: registry),
             *Models::Node.glob_read(__config__.current_cluster, '*', registry: registry)
-          ]
+          ].sort_by { |r| r.name }
 
           if group
             resources.select { |r| r.groups.include? group if r.respond_to?(:groups) }


### PR DESCRIPTION
This PR adds the `--group` flag to the `list` command, part of #272, allowing the user to filter the list of resources by group. Efforts made here also make filtering relatively easy for the same command in `Flight Cloud Client`.