### PR TITLE
List available groups

### DIFF
--- a/app/routes.rb
+++ b/app/routes.rb
@@ -63,7 +63,7 @@ module App
       end
 
       get '/groups' do
-        json Cloudware::Commands::Lists::Deployment.new.list_groups
+        json Cloudware::Commands::Lists::Deployment.new.client_list_groups
       end
     end
 

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -61,6 +61,10 @@ module App
       get '' do
         json Cloudware::Commands::Lists::Deployment.new.client_list(group: params[:group])
       end
+
+      get '/groups' do
+        json Cloudware::Commands::Lists::Deployment.new.list_groups
+      end
     end
 
     private

--- a/lib/cloudware/cli.rb
+++ b/lib/cloudware/cli.rb
@@ -262,6 +262,12 @@ module Cloudware
       action(c, Commands::Lists::Deployment)
     end
 
+    command 'list-groups' do |c|
+      cli_syntax(c)
+      c.description = 'List all groups within the cluster'
+      action(c, Commands::Lists::Deployment, method: :list_groups)
+    end
+
     command 'power' do |c|
       cli_syntax(c)
       c.sub_command_group = true

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -59,6 +59,10 @@ module Cloudware
           hashify_list(group)
         end
 
+        def client_list_groups
+          groups
+        end
+
         private
 
         def hashify_list(group)

--- a/lib/cloudware/commands/lists/deployment.rb
+++ b/lib/cloudware/commands/lists/deployment.rb
@@ -51,6 +51,10 @@ module Cloudware
           end
         end
 
+        def list_groups
+          puts groups
+        end
+
         def client_list(group: nil)
           hashify_list(group)
         end
@@ -75,6 +79,12 @@ module Cloudware
             *Models::Node.glob_read(__config__.current_cluster, '*', registry: registry)
           ].sort_by { |r| r.name }
             .select { |r| group ? (r.groups.include? group if r.respond_to?(:groups)) : r }
+        end
+
+        def groups
+          deployments(nil)
+            .map { |d| d.groups.prepend if d.respond_to?(:groups) }
+            .flatten.compact.uniq.sort.map { |g| g.prepend('- ') }
         end
       end
     end


### PR DESCRIPTION
This PR introduces the `list-groups` command, allowing the user to list all groups on the cluster. Any groups assigned to a resource within the cluster will be displayed with this command.

Also contains support for the same command in `Flight Cloud Client` for when that gets implemented.

Resolves #272.