### PR TITLE
Fix power command error on client

### DIFF
--- a/lib/cloudware/commands/power.rb
+++ b/lib/cloudware/commands/power.rb
@@ -87,7 +87,7 @@ module Cloudware
             memo[:errors][machine.name] = e.message
           rescue FlightConfig::MissingFile
             memo[:errors][machine.name] = 'The node does not exist'
-          rescue Module::DelegationError
+          rescue NoMethodError
             memo[:nodes][machine.name] = 'undeployed'
           end
         end


### PR DESCRIPTION
By adjusting which error is caught the power commands for `Flight Cloud Client` should no longer error 